### PR TITLE
Fix a few alerts from LGTM.com

### DIFF
--- a/topology/src/main/java/indexingTopology/bloom/BloomFilterHandler.java
+++ b/topology/src/main/java/indexingTopology/bloom/BloomFilterHandler.java
@@ -221,8 +221,9 @@ public class BloomFilterHandler {
     public void store() throws IOException, URISyntaxException {
 
         // writing to a local file before writing to HDFS, if file exist, overwrite it
-        OutputStream os = new FileOutputStream(this.localFileName, false);
-        this.bloomFilter.writeTo(os);
+        try (OutputStream os = new FileOutputStream(this.localFileName, false)) {
+            this.bloomFilter.writeTo(os);
+        }
 
         // writing to HDFS from local file
         BFHDFSHandler.writeHDFS(this.localFileName);

--- a/topology/src/main/java/indexingTopology/bloom/BloomFilterStore.java
+++ b/topology/src/main/java/indexingTopology/bloom/BloomFilterStore.java
@@ -28,7 +28,7 @@ public class BloomFilterStore {
     public BloomFilterStore(TopologyConfig config) {
         this.config = config;
         try {
-            Runtime.getRuntime().exec("mkdir -p " + config.metadataDir);
+            Runtime.getRuntime().exec(new String[]{ "mkdir", "-p", config.metadataDir });
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/topology/src/main/java/indexingTopology/bolt/MetadataServerBolt.java
+++ b/topology/src/main/java/indexingTopology/bolt/MetadataServerBolt.java
@@ -582,7 +582,7 @@ public class MetadataServerBolt<Key extends Number> extends BaseRichBolt {
     private void initializeMetadataFolder() {
         Runtime runtime = Runtime.getRuntime();
         try {
-            runtime.exec("mkdir -p " + config.metadataDir);
+            runtime.exec(new String[]{ "mkdir", "-p", config.metadataDir });
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/topology/src/main/java/indexingTopology/common/TimeDomain.java
+++ b/topology/src/main/java/indexingTopology/common/TimeDomain.java
@@ -1,6 +1,7 @@
 package indexingTopology.common;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * Created by acelzj on 12/2/17.
@@ -28,8 +29,8 @@ public class TimeDomain implements Serializable {
         if (this == obj) return true;
         if (obj instanceof TimeDomain) {
             TimeDomain timeDomain = (TimeDomain) obj;
-            return timeDomain.getStartTimestamp() == this.startTimestamp &&
-                    timeDomain.getEndTimestamp() == this.endTimestamp;
+            return Objects.equals(timeDomain.getStartTimestamp(), this.startTimestamp) &&
+                    Objects.equals(timeDomain.getEndTimestamp(), this.endTimestamp);
         }
         return false;
     }

--- a/topology/src/main/java/indexingTopology/index/Indexer.java
+++ b/topology/src/main/java/indexingTopology/index/Indexer.java
@@ -990,7 +990,7 @@ public class Indexer<DataType extends Number & Comparable<DataType>> extends Obs
         if (!config.HDFSFlag || config.HybridStorage) {
             Runtime runtime = Runtime.getRuntime();
             try {
-                runtime.exec("mkdir -p " + config.dataChunkDir);
+                runtime.exec(new String[]{ "mkdir", "-p", config.dataChunkDir });
             } catch (IOException e) {
                 e.printStackTrace();
             }


### PR DESCRIPTION
This PR fixes a few alerts flagged up by [LGTM.com](https://lgtm.com/projects/g/ADSC-Cloud/Waterwheel/alerts/?mode=tree). These are ones where I could quickly tell what was going on and what to do, but with your knowledge you would be able to make so much more of them.

- The first commit is where we are constructing and executing a command line by building up a string. What will happen is that the `Runtime` class will then split it back up based on the whitespace. This is a bit dangerous if `metadataDir` contains any spaces, and it could be very dangerous if an attacker is able to set that variable because they could then execute arbitrary code by naming the file something like `dirname; rm -rf /`. Building the command line by passing an array of strings is much safer and means they will be passed to `mkdir` as-is.

- The second commit fixes a place where we were comparing the boxed `Long` type using `==` which can sometimes do the right thing but often not. Using `.equals` or in this case `Objects.equals` will compare the values instead of whether they are the exact same java object.

- The third commit closes a `FileOutputStream` after it has been written to. This means we don't leak a file handle and if will definitely be flushed before the file is read from in `BFHDFSHandler.writeHDFS`.

Most of the other alerts look correct and worth fixing, but I think it would be a lot easier for you to address these as you know what's going on in the codebase. Full disclosure, I do work at the company that makes LGTM.com. What this means is that I've raised an issue internally for the "potential input resource leak" which seems to have a few false positives on your project, so in the future the results will hopefully be even better.